### PR TITLE
Verbose image loading error logs

### DIFF
--- a/images/src/main/java/com/stanfy/enroscar/images/ImageLoader.java
+++ b/images/src/main/java/com/stanfy/enroscar/images/ImageLoader.java
@@ -69,7 +69,7 @@ class ImageLoader implements Callable<Void> {
 
   // main thread
   public void removeTarget(final ImageConsumer consumer) {
-    if (DEBUG) { Log.d(TAG, "Cancel request: " + request.getKey() + "\nLoader: " + this); }
+    if (imagesManager.debug) { Log.d(TAG, "Cancel request: " + request.getKey() + "\nLoader: " + this); }
 
     consumer.onCancel(request.url);
 
@@ -79,7 +79,7 @@ class ImageLoader implements Callable<Void> {
 
       if (targets.isEmpty()) {
         if (!future.cancel(true)) {
-          if (DEBUG) { Log.d(TAG, "Can't cancel task so let's try to remove loader manually"); }
+          if (imagesManager.debug) { Log.d(TAG, "Can't cancel task so let's try to remove loader manually"); }
           imagesManager.currentLoads.remove(request.getKey(), this);
         }
       }
@@ -89,7 +89,7 @@ class ImageLoader implements Callable<Void> {
 
   // worker thread
   private void safeImageSet(final ImageResult result) {
-    if (DEBUG) { Log.v(ImagesManager.TAG, "Post setting drawable for " + request.getKey()); }
+    if (imagesManager.debug) { Log.v(ImagesManager.TAG, "Post setting drawable for " + request.getKey()); }
 
     synchronized (targets) {
       if (this.result != null) { throw new IllegalStateException("Result is already set"); }
@@ -110,12 +110,12 @@ class ImageLoader implements Callable<Void> {
           //noinspection ForLoopReplaceableByForEach
           for (int i = 0; i < count; i++) {
             final ImageConsumer imageHolder = targets.get(i);
-            if (DEBUG) {
+            if (imagesManager.debug) {
               Log.d(TAG, "Try to set " + imageHolder + " - " + request.getKey());
             }
             setToConsumer(imageHolder, result);
           }
-        } else if (DEBUG) {
+        } else if (imagesManager.debug) {
           Log.w(TAG, "set drawable: have no targets in list");
         }
 
@@ -236,7 +236,7 @@ class ImageLoader implements Callable<Void> {
 
   @Override
   public Void call() {
-    if (DEBUG) { Log.d(TAG, "Start image task"); }
+    if (imagesManager.debug) { Log.d(TAG, "Start image task"); }
     try {
 
       if (!imagesManager.waitForPause()) {
@@ -260,7 +260,7 @@ class ImageLoader implements Callable<Void> {
 
     } catch (final IOException e) {
 
-      if (DEBUG_IO) { Log.e(TAG, "IO error for " + request.url + ": " + e.getMessage()); }
+      if (imagesManager.debug) { Log.e(TAG, "IO error for " + request.url + ": " + e.getMessage()); }
       error(e);
 
     } catch (final Exception e) {
@@ -271,7 +271,7 @@ class ImageLoader implements Callable<Void> {
     } finally {
 
       final boolean removed = imagesManager.currentLoads.remove(request.getKey(), this);
-      if (DEBUG) {
+      if (imagesManager.debug) {
         Log.d(TAG, "Current loaders count: " + imagesManager.currentLoads.size());
         if (!removed) { Log.w(TAG, "Incorrect loader in currents for " + request.getKey()); }
       }

--- a/images/src/main/java/com/stanfy/enroscar/images/ImagesManager.java
+++ b/images/src/main/java/com/stanfy/enroscar/images/ImagesManager.java
@@ -49,10 +49,6 @@ public class ImagesManager implements InitializingBean {
 
   /** Logging tag. */
   static final String TAG = BEAN_NAME;
-  /** Debug flag. */
-  static final boolean DEBUG = false;
-  /** Debug flag. */
-  static final boolean DEBUG_IO = false;
 
   /** Max distance between sample factor and its nearest power of 2 to use the latter. */
   static final int MAX_POWER_OF_2_DISTANCE = 3;
@@ -77,7 +73,7 @@ public class ImagesManager implements InitializingBean {
   private boolean paused = false;
 
   /** Debug flag. */
-  boolean debug = DEBUG;
+  boolean debug = false;
 
   public ImagesManager(final Context context) {
     this.context = context.getApplicationContext();
@@ -156,7 +152,7 @@ public class ImagesManager implements InitializingBean {
           try {
             request.storeToDisk();
           } catch (final IOException e) {
-            if (DEBUG_IO) { Log.e(TAG, "IO error for " + request.url + ": " + e.getMessage()); }
+            if (debug) { Log.e(TAG, "IO error for " + request.url + ": " + e.getMessage()); }
           } catch (final Exception e) {
             Log.e(TAG, "Ignored error for ensureImages", e);
           }
@@ -452,7 +448,7 @@ public class ImagesManager implements InitializingBean {
 
     if (loader == null) {
 
-      if (DEBUG) { Log.d(TAG, "Start a new task"); }
+      if (debug) { Log.d(TAG, "Start a new task"); }
       loader = new ImageLoader(request, this);
       if (!loader.addTarget(consumer)) {
         throw new IllegalStateException("Cannot add target to the new loader");
@@ -474,7 +470,7 @@ public class ImagesManager implements InitializingBean {
    * @param bitmap bitmap
    */
   protected void memCacheImage(final String url, final Bitmap bitmap) {
-    if (DEBUG) { Log.d(TAG, "Memcache for " + url); }
+    if (debug) { Log.d(TAG, "Memcache for " + url); }
     memCache.putElement(url, bitmap);
   }
 


### PR DESCRIPTION
ImageManager simply eats all helpful error messages so you have no clue why your image hadn't load.

Real life example which gives you nothing:

```
enroscar.ImagesManager﹕ Process url content://com.example/brandpack/restaurant_logo/snoac_st
enroscar.ImagesManager﹕ Not in mem content://com.example/brandpack/restaurant_logo/snoac_st
enroscar.ImagesManager﹕ Set loading for content://com.example/brandpack/restaurant_logo/snoac_st!160x160
enroscar.ImagesManager﹕ Key content://com.example/brandpack/restaurant_logo/snoac_st!160x160
enroscar.ImagesManager﹕ Current loaders count: 1
```
