### PR TITLE
Move 'images' dependency from 'ui' module to 'assist'

### DIFF
--- a/assist/src/main/java/com/stanfy/enroscar/assist/DefaultBeansManager.java
+++ b/assist/src/main/java/com/stanfy/enroscar/assist/DefaultBeansManager.java
@@ -5,6 +5,7 @@ import android.content.Context;
 
 import com.stanfy.enroscar.activities.ActivityBehaviorFactory;
 import com.stanfy.enroscar.activities.CrucialGUIOperationManager;
+import com.stanfy.enroscar.assist.util.ImagesManagerCrucialGUIOperationListener;
 import com.stanfy.enroscar.beans.BeanUtils;
 import com.stanfy.enroscar.beans.BeansManager;
 import com.stanfy.enroscar.images.ImagesManager;
@@ -13,8 +14,8 @@ import com.stanfy.enroscar.images.views.ImageConsumers;
 import com.stanfy.enroscar.io.BuffersPool;
 import com.stanfy.enroscar.net.EnroscarConnectionsEngine;
 import com.stanfy.enroscar.net.UrlConnectionBuilderFactory;
-import com.stanfy.enroscar.rest.RemoteServerApiConfiguration;
 import com.stanfy.enroscar.net.operation.SimpleRequestBuilder;
+import com.stanfy.enroscar.rest.RemoteServerApiConfiguration;
 import com.stanfy.enroscar.rest.request.net.BaseRequestDescriptionConverter;
 import com.stanfy.enroscar.rest.response.handler.GsonContentHandler;
 import com.stanfy.enroscar.rest.response.handler.StringContentHandler;
@@ -123,6 +124,7 @@ public class DefaultBeansManager extends BeansManager {
     public Editor activitiesBehavior() {
       put(ActivityBehaviorFactory.class);
       put(CrucialGUIOperationManager.class);
+      put(ImagesManagerCrucialGUIOperationListener.class);
       return this;
     }
 

--- a/assist/src/main/java/com/stanfy/enroscar/assist/util/ImagesManagerCrucialGUIOperationListener.java
+++ b/assist/src/main/java/com/stanfy/enroscar/assist/util/ImagesManagerCrucialGUIOperationListener.java
@@ -1,0 +1,45 @@
+package com.stanfy.enroscar.assist.util;
+
+import com.stanfy.enroscar.activities.CrucialGUIOperationManager;
+import com.stanfy.enroscar.beans.BeansContainer;
+import com.stanfy.enroscar.beans.EnroscarBean;
+import com.stanfy.enroscar.beans.InitializingBean;
+import com.stanfy.enroscar.images.ImagesManager;
+
+/**
+ * Pause image loading on crucial GUI operations.
+ * @author Olexandr Tereshchuk - "Stanfy"
+ * @since 28.05.14
+ */
+@EnroscarBean(value = ImagesManagerCrucialGUIOperationListener.BEAN_NAME)
+public class ImagesManagerCrucialGUIOperationListener implements CrucialGUIOperationManager.CrucialGUIOperationListener, InitializingBean {
+
+  /** Bean name. */
+  public static final String BEAN_NAME = "ImagesManagerCrucialGUIOperationListener";
+
+  /** Images manager. */
+  private ImagesManager imagesManager;
+
+  @Override
+  public void onStartCrucialGUIOperation() {
+    if (imagesManager != null) {
+      imagesManager.pauseLoading();
+    }
+  }
+
+  @Override
+  public void onFinishCrucialGUIOperation() {
+    if (imagesManager != null) {
+      imagesManager.resumeLoading();
+    }
+  }
+
+  @Override
+  public void onInitializationFinished(final BeansContainer beansContainer) {
+    imagesManager = beansContainer.getBean(ImagesManager.class);
+    final CrucialGUIOperationManager manager = beansContainer.getBean(CrucialGUIOperationManager.class);
+    if (manager != null) {
+      manager.addCrucialGUIOperationListener(this);
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ configure(libraryModules) {
       androidTestCompile it
     }
 
-    testCompile group: 'org.robolectric', name: 'robolectric', version: '2.3-SNAPSHOT'
+    testCompile group: 'org.robolectric', name: 'robolectric', version: '2.3'
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.easytesting:fest-util:1.2.5'
   }

--- a/content/async-compiler/build.gradle
+++ b/content/async-compiler/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   testCompile 'com.google.guava:guava:16.0.1'
   testCompile 'org.truth0:truth:0.13'
 
-  testCompile group: 'org.robolectric', name: 'robolectric', version: '2.3-SNAPSHOT'
+  testCompile group: 'org.robolectric', name: 'robolectric', version: '2.3'
   testRuntime files("${System.properties['java.home']}/../lib/tools.jar")
   testRuntime files("${System.env['ANDROID_HOME']}/platforms/android-19/android.jar")
 }

--- a/gradle/tests-ide-hack.gradle
+++ b/gradle/tests-ide-hack.gradle
@@ -11,6 +11,6 @@ android {
 
 dependencies {
   androidTestCompile 'junit:junit:4.11'
-  androidTestCompile 'org.robolectric:robolectric:2.3-SNAPSHOT'
+  androidTestCompile 'org.robolectric:robolectric:2.3'
   androidTestCompile 'org.mockito:mockito-all:1.9.5'
 }

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,4 +1,4 @@
-dependOnProjects([':beans', ':net', ':stats', ':images'])
+dependOnProjects([':beans', ':net', ':stats'])
 
 dependencies {
   compile 'com.android.support:support-v4:19.1.0'

--- a/ui/src/main/java/com/stanfy/enroscar/activities/CrucialGUIOperationManager.java
+++ b/ui/src/main/java/com/stanfy/enroscar/activities/CrucialGUIOperationManager.java
@@ -1,21 +1,18 @@
 package com.stanfy.enroscar.activities;
 
-import java.util.HashSet;
-
 import android.os.Looper;
 import android.util.Log;
 
-import com.stanfy.enroscar.beans.BeansContainer;
 import com.stanfy.enroscar.beans.EnroscarBean;
-import com.stanfy.enroscar.beans.InitializingBean;
-import com.stanfy.enroscar.images.ImagesManager;
+
+import java.util.HashSet;
 
 /**
  * Crucial GUI operation manager.
  * @author Roman Mazur (Stanfy - http://stanfy.com)
  */
 @EnroscarBean(value = CrucialGUIOperationManager.BEAN_NAME)
-public class CrucialGUIOperationManager implements InitializingBean {
+public class CrucialGUIOperationManager {
 
   /** Bean name. */
   public static final String BEAN_NAME = "CrucialGUIOperationManager";
@@ -28,9 +25,6 @@ public class CrucialGUIOperationManager implements InitializingBean {
 
   /** Crucial GUI operation listeners. */
   private HashSet<CrucialGUIOperationListener> crucialGuiOperationListeners;
-
-  /** Images manager. */
-  private ImagesManager imagesManager;
 
   private void checkThread() {
     if (Looper.myLooper() != Looper.getMainLooper()) {
@@ -46,9 +40,6 @@ public class CrucialGUIOperationManager implements InitializingBean {
   public void dispatchCrucialGUIOperationStart() {
     checkThread();
     crucialGuiOperationRunning = true;
-    if (imagesManager != null) {
-      imagesManager.pauseLoading();
-    }
     final HashSet<CrucialGUIOperationListener> listeners = crucialGuiOperationListeners;
     if (listeners != null) {
       for (final CrucialGUIOperationListener crucialGUIOperationListener : listeners) {
@@ -68,9 +59,6 @@ public class CrucialGUIOperationManager implements InitializingBean {
     checkThread();
     if (!crucialGuiOperationRunning) { return; }
     crucialGuiOperationRunning = false;
-    if (imagesManager != null) {
-      imagesManager.resumeLoading();
-    }
     final HashSet<CrucialGUIOperationListener> listeners = crucialGuiOperationListeners;
     if (listeners != null) {
       for (final CrucialGUIOperationListener crucialGUIOperationListener : listeners) {
@@ -103,11 +91,6 @@ public class CrucialGUIOperationManager implements InitializingBean {
     checkThread();
     if (crucialGuiOperationListeners == null) { return; }
     crucialGuiOperationListeners.remove(listener);
-  }
-
-  @Override
-  public void onInitializationFinished(final BeansContainer container) {
-    this.imagesManager = container.getBean(ImagesManager.BEAN_NAME, ImagesManager.class);
   }
   
   /**


### PR DESCRIPTION
`CrucialGUIOperationManager` has no direct reference to the `ImagesManager` now - `ImagesManagerCrucialGUIOperationListener` located in `assist` module, just registers itself as regular listener and implements the behavior removed from `ui` module
