### PR TITLE
Cancel Async on Loader reset

### DIFF
--- a/async/core/src/main/java/com/stanfy/enroscar/async/internal/WrapAsyncLoader.java
+++ b/async/core/src/main/java/com/stanfy/enroscar/async/internal/WrapAsyncLoader.java
@@ -102,6 +102,11 @@ final class WrapAsyncLoader<D> extends Loader<WrapAsyncLoader.Result<D>> {
       onReleaseData(result);
       result = null;
     }
+
+    if (async != null) {
+      async.cancel();
+      async = null;
+    }
   }
 
   private void onReleaseData(final Result<D> result) {

--- a/async/core/src/test/java/com/stanfy/enroscar/async/internal/WrapAsyncLoaderTest.java
+++ b/async/core/src/test/java/com/stanfy/enroscar/async/internal/WrapAsyncLoaderTest.java
@@ -145,4 +145,11 @@ public class WrapAsyncLoaderTest {
     assertThat(cancelInvoked).isTrue();
   }
 
+  @Test
+  public void resetShouldCancelAsyncResult() {
+    loader.startLoading();
+    loader.reset();
+    assertThat(cancelInvoked).isTrue();
+  }
+
 }


### PR DESCRIPTION
When resetting the Loader, we must free all the resources and wait for next `startLoading` call to start working again.

Would fix https://github.com/stanfy/enroscar/issues/60