### PR TITLE
Add access to the wrapped Goro instance

### DIFF
--- a/goro/core/src/main/java/com/stanfy/enroscar/goro/support/AsyncGoro.java
+++ b/goro/core/src/main/java/com/stanfy/enroscar/goro/support/AsyncGoro.java
@@ -35,6 +35,9 @@ public class AsyncGoro {
     return schedule(Goro.DEFAULT_QUEUE, task);
   }
 
+  /** @return wrapped {@link Goro} instance */
+  public Goro getCore() { return goro; }
+
   /** Implementation. */
   private final class GoroAsync<T> implements Async<T> {
 

--- a/goro/core/src/main/java/com/stanfy/enroscar/goro/support/RxGoro.java
+++ b/goro/core/src/main/java/com/stanfy/enroscar/goro/support/RxGoro.java
@@ -51,4 +51,7 @@ public class RxGoro {
     });
   }
 
+  /** @return wrapped {@link Goro} instance */
+  public Goro getCore() { return goro; }
+
 }


### PR DESCRIPTION
 - Add access to the wrapped Goro instance so clients are not forced to store references to both objects